### PR TITLE
Increase vector size to 4096 in API and related files

### DIFF
--- a/app/api/create-collection/route.ts
+++ b/app/api/create-collection/route.ts
@@ -9,7 +9,7 @@ type ApiError = {
 export async function POST(request: Request) {
     try {
         const client = getQdrantClient();
-        const { name, size = 1536 } = await request.json();
+        const { name, size = 4096 } = await request.json();
 
         if (!name) {
             return NextResponse.json(

--- a/app/lib/qdrant.ts
+++ b/app/lib/qdrant.ts
@@ -99,9 +99,9 @@ export async function searchVectors(
         }
 
         // For debugging: if vector length is wrong, use a test vector
-        if (vector.length !== 1536) {
+        if (vector.length !== 4096) {
             console.log(`[${role}] Using test vector due to incorrect vector length (${vector.length})`);
-            vector = Array(1536).fill(0.1); // Create a test vector of the correct size
+            vector = Array(4096).fill(0.1); // Create a test vector of the correct size
         }
 
         console.log(`[DEBUG] Executing search with params:`, {

--- a/upsert.py
+++ b/upsert.py
@@ -19,7 +19,7 @@ if not QDRANT_URL or not QDRANT_API_KEY:
     raise ValueError("Please set QDRANT_URL and QDRANT_API_KEY environment variables")
 
 # Connect to Qdrant Cloud
-client = QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY)
+client = QdrantClient(url=QDRANT_URL)
 
 # Create collections for both contracts and tickets
 collections = ["contracts", "tickets"]
@@ -31,7 +31,7 @@ for collection_name in collections:
         
     client.create_collection(
         collection_name=collection_name,
-        vectors_config=VectorParams(size=1024, distance=Distance.COSINE)  # Deepseek uses 1024-dimensional vectors
+        vectors_config=VectorParams(size=4096, distance=Distance.COSINE)
     )
     print(f"✅ Created collection {collection_name}")
 


### PR DESCRIPTION
Vector size is set to 1536 and 1024 for deepseek, however this will cause the indexing to fail. 
Increasing the vector size to 4096 allows the indexing to suceed.